### PR TITLE
Fix display of addons when viewed within Firefox

### DIFF
--- a/vendor/assets/stylesheets/pure_css_reset.css
+++ b/vendor/assets/stylesheets/pure_css_reset.css
@@ -282,6 +282,7 @@ input[type="file"] {
   border-collapse: separate;
   display: table;
   position: relative;
+  line-height: normal;
 }
 
 .pure-form .addon-wrapper input[type="text"],


### PR DESCRIPTION
This brings the display of addons within Firefox to match that in Chrome and Safari

**Before**
![screen shot 2016-07-04 at 09 17 08](https://cloud.githubusercontent.com/assets/5688326/16548288/efa31a2e-41c8-11e6-9e23-3a1030094fd6.png)
**After**
![screen shot 2016-07-04 at 09 20 36](https://cloud.githubusercontent.com/assets/5688326/16548291/f695df56-41c8-11e6-8591-50cff7e951e4.png)
